### PR TITLE
Keep escaped quotes from triggering quoted string patterns

### DIFF
--- a/Antlr.tmLanguage
+++ b/Antlr.tmLanguage
@@ -15,17 +15,17 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>"</string>
+			<string>(?&lt;!\\)"|(?&lt;!\\)\\\\"|[\\]{4}"</string>
 			<key>comment</key>
 			<string>Double quoted strings or characters</string>
 			<key>end</key>
-			<string>(?&lt;=[^\\])"|(?&lt;=[^\\])\\\\"|[\\]{4}"</string>
+			<string>(?&lt;!\\)"|(?&lt;!\\)\\\\"|[\\]{4}"</string>
 			<key>name</key>
 			<string>string.quoted.double.single-line.antlr</string>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>'</string>
+			<string>(?&lt;=[^\\])'|(?&lt;=[^\\])\\\\'|[\\]{4}'</string>
 			<key>comment</key>
 			<string>Single quoted strings or characters</string>
 			<key>end</key>


### PR DESCRIPTION
Might show up elsewhere, but this is mainly for quote characters that appear in regex character classes. For example:
fragment StringChar: ~[\"\\\r\n] ;
Previously, the above fragment would cause the rest of the document to be highlighted as a string.